### PR TITLE
Expand training README with data curation, downsampling, and alignment details

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -23,6 +23,18 @@ export PYTHONPATH="<ROOT_DIRECTORY>:$PYTHONPATH"
 7. To train the model: Run 
 ```python3 <root_repository>/training/main.py 64 15```
 -batch_size = 64, epoches=15.
+
+## Data curation and preprocessing details
+
+All data were sourced from GISAID on 2022-06-16 using two files: (1) the multiple-sequence alignment (MSA) FASTA file `alignment-and-proteins/msa_2022-06-16/2022-06-16_unmasked.fa` and (2) the metadata file `variant_surveillance_tsv_2022_06_16/variant_surveillance.tsv`. The workflow first filters metadata records to WHO VOC labels (`Alpha`, `Beta`, `Gamma`, `Delta`, `Omicron`) by extracting these names from the `Variant` column and dropping non-matching entries.
+
+To address class imbalance, the pipeline performs class-wise random downsampling at the label table stage using the minority VOC count as the target sample size (`training/data_prep.py`). In this snapshot, the limiting class is Beta (~45k sequences), so each VOC is downsampled to this size before sequence matching. IDs are then matched against the aligned FASTA file, and exact duplicate sequence strings are removed. Because some sampled IDs are not retained after sequence matching/deduplication, the final balanced pool used for model construction is capped by fixed per-class sampling in the next step.
+
+For train/test construction (`training/split_data_train_val_test.py`), the code samples 32,000 sequences per VOC for training (160,000 total) and 8,000 per VOC for test (40,000 total), giving 200,000 sequences overall. A duplicate check is run after concatenating train and test and reports zero cross-split duplicates. Validation data are created from the training portion via the configurable split ratio in `constants/constants.py`.
+
+Alignment handling is inherited directly from the GISAID MSA input: all sequences are already aligned to a common length (29,891 positions), and no additional realignment is performed in this repository. Gap characters (`-`) are preserved as an explicit state during encoding so that insertions/deletions remain model-visible.
+
+For model input, each aligned nucleotide string is converted position-wise into a 7-channel one-hot representation (`one_hot/one_hot.py`) with the fixed symbol order `['-', 'a', 'c', 'g', 'i', 'n', 't']`: canonical bases (A/C/G/T), gap (`-`), ambiguous base (`N`), and an `i` bucket for any non-standard/other character not in the predefined alphabet. Concatenating 29,891 positions yields an input tensor of shape `(N, 29,891, 7)`, where `N` is the number of sequences in the corresponding split.
  
 
 ## Summary of our model


### PR DESCRIPTION
### Motivation
- Improve reproducibility by documenting how GISAID inputs are filtered, downsampled, matched, deduplicated, and encoded before training so readers can understand the data curation and alignment assumptions used by the experiments.

### Description
- Added a `Data curation and preprocessing details` section to `training/README.md` that explains the two GISAID source files used, VOC filtering, class-wise random downsampling (minority-class target), ID-to-MSA matching and duplicate removal, the per-class train/test sampling that produces 160k training + 40k test sequences, the use of the provided GISAID MSA (no repo-side realignment) with gaps preserved, and the 7-channel one-hot encoding scheme (`['-', 'a', 'c', 'g', 'i', 'n', 't']`) producing input tensors of shape `(N, 29891, 7)`.

### Testing
- Verified the README update and consistency with the implementation by inspecting the updated file contents (`sed`/`nl`), and by cross-checking relevant code paths in `training/data_prep.py`, `training/split_data_train_val_test.py`, `one_hot/one_hot.py`, and `constants/constants.py`, with the inspections showing the documentation matches the code behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699219106188832cb4b59b2bba179002)