### PR TITLE
Document decision-tree baseline models and default sample sizes

### DIFF
--- a/decision_tree/README.md
+++ b/decision_tree/README.md
@@ -3,6 +3,21 @@
 ## 1. Preparing data
 Because of limitations on memory, for decision trees we cannot use the entire training and test datasets we used for the 2-layer CNN, then we selected 2,000 sequences from each VOC, splitting 20% of them for testing. 
 
+### Baseline models and sample sizes
+The tree-based baselines used to compare against the CNN are:
+
+* Random Forest (`rf`)
+* XGBoost (`xgb`)
+* CatBoost (`cat`)
+
+With the default `-num 2000` setting in `data_dt.py` and five VOC classes, this creates:
+
+* 10,000 total sequences for decision-tree experiments
+* 8,000 training sequences (80%)
+* 2,000 test sequences (20%)
+
+For hyperparameter fine-tuning, `fine_tunning.py` uses 500 sequences per VOC by default (2,500 total sequences).
+
 To create these datasets, first create a folder named `data`, then run:
 ```
 python3 <root_repository>/decision_tree/data_dt.py


### PR DESCRIPTION
### Motivation
- Clarify which tree-based baseline models are used for decision-tree experiments and make the default dataset sizing explicit so users can reproduce training and tuning runs.

### Description
- Add a "Baseline models and sample sizes" subsection to `decision_tree/README.md` that lists the baselines (Random Forest `rf`, XGBoost `xgb`, CatBoost `cat`) and documents the defaults for `-num 2000` across five VOCs (10,000 total, 8,000 train / 2,000 test) and the default fine-tuning subset (500 per VOC, 2,500 total).

### Testing
- Ran `nl -ba decision_tree/README.md | sed -n '1,90p'` to verify the README content and it succeeded.
- Ran `git status --short && git rev-parse --short HEAD` to confirm the working tree state and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699238cd9f0c832c87c8b04ea90d947e)